### PR TITLE
Block orgs.one.

### DIFF
--- a/chrome/sites.js
+++ b/chrome/sites.js
@@ -248,7 +248,8 @@ var sites = [
     "pixpo.net",
     "please.news",
     "uuread.cc",
-    "lookforward.cc"
+    "lookforward.cc",
+    "orgs.one"
 ];
 
 module.exports = sites;


### PR DESCRIPTION
Noticed from http://www.mooner.orgs.one/ this site, but we can use Google
to notice that entire *.orgs.one is a content farm:
https://www.google.com/search?q=site%3Aorgs.one